### PR TITLE
Release v0.0.5: shadow-method bug fix + obj._ proxy migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,18 @@ proxy.
 
 - **Data with method-name keys is accepted.** `RNS({"items": [...]})`
   works; the value is stored under `obj["items"]` and `obj.items`. A
-  `DeprecationWarning` reminds you that the matching method must now be
-  called as `obj._.items()`.
+  `FutureWarning` reminds you that the matching method must now be
+  called as `obj._.items()`. `FutureWarning` (not `DeprecationWarning`)
+  so the signal surfaces under Python's default warning filter — you'll
+  see it the first time a user-supplied key collides, without needing
+  `-W default`.
 - **Direct calls to the legacy methods** (`obj.to_dict()`,
-  `obj.items()`, …) also emit `DeprecationWarning` and forward to the
+  `obj.items()`, …) emit `DeprecationWarning` and forward to the
   proxy. They will be removed in **v0.1.0** (the first stable release);
-  migrate to `obj._.<method>(...)` before then.
+  migrate to `obj._.<method>(...)` before then. Because this category
+  is silenced by Python's default filter, run with `-W default` or
+  enable warnings in your test runner (e.g. `pytest -W default`) to
+  see these during migration.
 - **`_` itself is reserved.** Data keys named `"_"` raise `KeyError`.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Key features:
 
 - Recursive conversion of nested dicts/lists
 - Attribute and dict access (`rn.a` and `rn["a"]`)
-- Chain-key access (`rn.val_get("a.b.c")`)
+- Chain-key access (`rn._.val_get("a.b.c")`)
 - Array indexing and append syntax (`items[].0`, `items[].#`)
 - Typed, zero-dependency, pure Python
 

--- a/benchmarks/bench_chain_keys.py
+++ b/benchmarks/bench_chain_keys.py
@@ -29,13 +29,13 @@ def bench_val_get(n: int = 10_000) -> float:
     data = build_deep_structure(5)
     ns = RNS(data)
     chain = "level_4.level_3.level_2.level_1.level_0.leaf"
-    t = timeit.timeit(lambda: ns.val_get(chain), number=n)
+    t = timeit.timeit(lambda: ns._.val_get(chain), number=n)
     return t
 
 
 def bench_val_set(n: int = 10_000) -> float:
     ns = RNS({})
-    t = timeit.timeit(lambda: ns.val_set("a.b.c.d.e", "value"), number=n)
+    t = timeit.timeit(lambda: ns._.val_set("a.b.c.d.e", "value"), number=n)
     return t
 
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -107,8 +107,12 @@ Two tiers of names are reserved on the class:
   ``values``, ``items``, ``copy``, ``deepcopy``, ``pop``, ``as_schema``,
   ``to_json``/``from_json``, ``to_toml``/``from_toml``, etc. Storing a
   data field with one of these names is allowed but emits a
-  ``DeprecationWarning``: ``obj[name]`` / ``obj.name`` will return the
+  ``FutureWarning``: ``obj[name]`` / ``obj.name`` will return the
   data, and the method remains reachable via ``obj._.<name>(...)``.
+  ``FutureWarning`` is used (instead of ``DeprecationWarning``) so the
+  collision is visible under Python's default warning filter — you do
+  not need ``-W default`` to see a shadow event the first time it
+  happens.
 
 Classmethod Factories
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guides/method-proxy.rst
+++ b/docs/guides/method-proxy.rst
@@ -19,7 +19,7 @@ Without the proxy:
 
 The library solves this by giving every method a second, collision-free
 home: ``obj._``. Data with method-name keys is accepted (you'll see a
-``DeprecationWarning`` reminding you that the matching method must be
+``FutureWarning`` reminding you that the matching method must be
 called as ``obj._.<name>()``); only the ``_`` proxy itself is reserved
 and raises ``KeyError`` if you try to use ``"_"`` as a data key.
 
@@ -51,8 +51,8 @@ The migration runs over three releases:
 * **Phase 1 (this release).** ``obj._`` ships alongside the legacy
   direct-call API. Direct method calls emit a ``DeprecationWarning``
   pointing to the proxy form. Data keys that collide with public method
-  names are accepted with a similar ``DeprecationWarning``; only ``_``
-  itself raises.
+  names are accepted with a ``FutureWarning`` (a louder category,
+  visible under Python's default filter); only ``_`` itself raises.
 * **Phase 2.** The warning is tightened (raised in stricter test
   configurations).
 * **Phase 3 (next major release).** Direct method access is removed.
@@ -70,6 +70,47 @@ What lives where
 * **Dunders** (``__setitem__``, ``__len__``, ``__copy__``, ...) and
   private helpers (``_re``, ``_chain_set_array``, ...) stay on the
   class. They are not part of the public API.
+
+Warning visibility (read this if you're integrating RNS)
+--------------------------------------------------------
+
+RNS emits two warning categories with intentionally different visibility:
+
+* **Shadow events** — your data key collides with a method name
+  (e.g. ``RNS({"items": "..."})``). Emitted as ``FutureWarning``.
+  ``FutureWarning`` is shown under Python's **default** filter, so the
+  collision surfaces in production logs the first time it happens —
+  exactly the case where the in-memory object is now subtly broken
+  (``obj.items`` is a string, ``obj.items()`` raises ``TypeError``)
+  while the JSON output still looks correct.
+
+* **Direct-call deprecation** — you called ``obj.to_dict()`` instead
+  of ``obj._.to_dict()``. Emitted as ``DeprecationWarning``. Python's
+  default filter suppresses ``DeprecationWarning`` raised outside
+  ``__main__``, so these will be silent in normal application runs.
+  To see them during migration, opt in:
+
+  .. code-block:: bash
+
+      # one-off
+      PYTHONWARNINGS=default python app.py
+
+      # in CI / tests
+      pytest -W default
+
+  Or, in a logging-based app, route ``warnings`` through your logger
+  at startup so the filter no longer applies:
+
+  .. code-block:: python
+
+      import logging
+      logging.captureWarnings(True)
+
+The rationale for the split: a shadow event is caused by **end-user
+data** flowing into RNS and silently breaks the in-memory object, so
+it must be unmissable. A direct-call deprecation is a **developer**
+choosing the legacy API, and migration is something the developer
+opts into when they're ready — the standard Python convention.
 
 Suppressing the warning during migration
 ----------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,12 @@ Basic Usage:
    etc. — still work but emit ``DeprecationWarning`` and will be removed
    in **v0.1.0** (the first stable release). Use the ``obj._`` proxy
    instead: ``rn._.to_dict()``, ``rn._.items()``, ``rn._.val_set(...)``.
+
+   Data keys that collide with a method name (e.g. ``RNS({"items": ...})``)
+   emit ``FutureWarning`` — a louder category, visible under Python's
+   default filter — because the collision is caused by user data and
+   should not require ``-W default`` to surface.
+
    See :doc:`guides/method-proxy` for the full migration plan.
 
 Contents

--- a/examples/advanced/10_schema_conversion.py
+++ b/examples/advanced/10_schema_conversion.py
@@ -29,12 +29,12 @@ raw = RNS(
 )
 
 # Convert to a typed dataclass
-db = raw.as_schema(DatabaseConfig)
+db = raw._.as_schema(DatabaseConfig)
 print(f"DB: {db.host}:{db.port}/{db.name}")
 print(f"Type: {type(db).__name__}")  # DatabaseConfig
 
 # Works with any dataclass
 app_data = RNS({"debug": True, "version": "2.0.1"})
-app = app_data.as_schema(AppConfig)
+app = app_data._.as_schema(AppConfig)
 print(f"\nApp v{app.version}, debug={app.debug}")
 print(f"Type: {type(app).__name__}")  # AppConfig

--- a/examples/advanced/11_flatten_reconstruct.py
+++ b/examples/advanced/11_flatten_reconstruct.py
@@ -18,24 +18,24 @@ data = RNS(
 )
 
 # Flatten with dot separator
-flat_dot = data.to_dict(flatten_sep=".")
+flat_dot = data._.to_dict(flatten_sep=".")
 print("Flat (dot):")
 pprint(flat_dot)
 
 # Flatten with underscore separator
-flat_us = data.to_dict(flatten_sep="_")
+flat_us = data._.to_dict(flatten_sep="_")
 print("\nFlat (underscore):")
 pprint(flat_us)
 
 # Reconstruct from flat dict using chain keys
 reconstructed = RNS({})
 for key, value in flat_dot.items():
-    reconstructed.val_set(key, value)
+    reconstructed._.val_set(key, value)
 
 print("\nReconstructed:")
 print(f"  model.name = {reconstructed.model.name}")
 print(f"  training.lr = {reconstructed.training.lr}")
 
 # Verify round-trip
-assert reconstructed.to_dict() == data.to_dict()
+assert reconstructed._.to_dict() == data._.to_dict()
 print("\nRound-trip verified!")

--- a/examples/advanced/12_custom_iter_types.py
+++ b/examples/advanced/12_custom_iter_types.py
@@ -27,7 +27,7 @@ print(f"Nested set:   {nested.data.labels}")
 
 # raw_key mode disables key normalization
 raw = RNS({"my-key": 1, "other.key": 2}, use_raw_key=True)
-print(f"\nRaw keys: {raw.keys()}")
+print(f"\nRaw keys: {raw._.keys()}")
 # Access with original key names (no normalization)
 print(f"my-key: {getattr(raw, 'my-key')}")
 print(f"other.key: {getattr(raw, 'other.key')}")

--- a/examples/advanced/13_method_proxy.py
+++ b/examples/advanced/13_method_proxy.py
@@ -12,11 +12,14 @@ from recursivenamespace import RNS
 
 # ── 1. Collision case ────────────────────────────────────────────
 # Method names are SOFT-protected: data is accepted, a
-# DeprecationWarning tells you the matching method must be called via
-# obj._.<name>().
+# FutureWarning tells you the matching method must be called via
+# obj._.<name>(). FutureWarning (not DeprecationWarning) so the
+# collision is visible under Python's default warning filter — the
+# in-memory object is now broken (collision.items is the list, not the
+# method), and that should not require -W default to notice.
 
 with warnings.catch_warnings(record=True) as captured:
-    warnings.simplefilter("always", DeprecationWarning)
+    warnings.simplefilter("always", FutureWarning)
     collision = RNS({"items": [1, 2, 3], "name": "John"})
     print(f"Stored data: items={collision['items']}, name={collision.name}")
     print(f"Shadow warning: {captured[0].message}")

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -19,17 +19,17 @@ print(results["metrics"].accuracy)  # 98.79
 
 
 # I can convert just the metrics to dictionary
-metrics_dict = results.metrics.to_dict()
+metrics_dict = results.metrics._.to_dict()
 print(metrics_dict)  # {'accuracy': 98.79, 'f1': 97.62}
 
 # Or I can convert all of it to a nested dictionary
-output_dict = results.to_dict()
+output_dict = results._.to_dict()
 pprint(output_dict)
 # {'metrics': {'accuracy': 98.79, 'f1': 97.62},
 #  'params':  {'alpha': 1.0, 'beta': 2.0}}
 
 # I can also flatten the keys using a separator
-flat_dict = results.to_dict(flatten_sep="_")
+flat_dict = results._.to_dict(flatten_sep="_")
 pprint(flat_dict)
 # {'metrics_accuracy': 98.79,
 #  'metrics_f1': 97.62,

--- a/examples/basic_usage_2.py
+++ b/examples/basic_usage_2.py
@@ -23,11 +23,11 @@ print("rn.address.street:", rn.address.street)  # Output: 123 Main St
 
 print("------------")
 print("to_dict():")
-pprint(rn.to_dict())
+pprint(rn._.to_dict())
 
 print("------------")
 print("to_dict() flattening with '_' separator:")
-pprint(rn.to_dict(flatten_sep="_"))
+pprint(rn._.to_dict(flatten_sep="_"))
 
 
 print("------------")
@@ -35,8 +35,8 @@ print("You can also use it as a dictionary:")
 print(len(rn))  # 3
 print(len(rn.address))  # 2
 print(len(rn["address"]))  # 2
-print(rn.keys())  # ['name', 'age', 'address']
-for k, v in rn.items():
+print(rn._.keys())  # ['name', 'age', 'address']
+for k, v in rn._.items():
     print(f"  {k}: {v}")
 
 print("------------")

--- a/examples/click_package.py
+++ b/examples/click_package.py
@@ -81,7 +81,7 @@ def evaluate(**options):
         k,
         v,
     ) in (
-        results.items()
+        results._.items()
     ):  # results is RNS type. But you can treat is as dictionary.
         print(f" {str(k):<10s}: {v:8.4f}")
 

--- a/examples/intermediate/05_json_toml.py
+++ b/examples/intermediate/05_json_toml.py
@@ -12,7 +12,7 @@ config = RNS(
 )
 
 # ── JSON ────────────────────────────────────────────────────────
-json_str = config.to_json(indent=2, sort_keys=True)
+json_str = config._.to_json(indent=2, sort_keys=True)
 print("JSON output:")
 print(json_str)
 
@@ -22,12 +22,12 @@ assert loaded.app.name == "MyApp"
 assert loaded.database.port == 5432
 
 # File I/O
-config.save_json("/tmp/rns_example_config.json")
+config._.save_json("/tmp/rns_example_config.json")
 from_file = RNS.load_json("/tmp/rns_example_config.json")
 assert from_file == config
 
 # ── TOML ────────────────────────────────────────────────────────
-toml_str = config.to_toml()
+toml_str = config._.to_toml()
 print("\nTOML output:")
 print(toml_str)
 
@@ -36,7 +36,7 @@ loaded_toml = RNS.from_toml(toml_str)
 assert loaded_toml.app.name == "MyApp"
 
 # File I/O
-config.save_toml("/tmp/rns_example_config.toml")
+config._.save_toml("/tmp/rns_example_config.toml")
 from_toml_file = RNS.load_toml("/tmp/rns_example_config.toml")
 assert from_toml_file.app.name == "MyApp"
 

--- a/examples/intermediate/06_chain_keys.py
+++ b/examples/intermediate/06_chain_keys.py
@@ -5,30 +5,30 @@ from recursivenamespace import RNS
 ns = RNS({})
 
 # Dot-separated chain keys create nested namespaces automatically
-ns.val_set("server.host", "localhost")
-ns.val_set("server.port", 8080)
-print("server.host:", ns.val_get("server.host"))  # localhost
-print("server.port:", ns.val_get("server.port"))  # 8080
+ns._.val_set("server.host", "localhost")
+ns._.val_set("server.port", 8080)
+print("server.host:", ns._.val_get("server.host"))  # localhost
+print("server.port:", ns._.val_get("server.port"))  # 8080
 
 # Array operations with []
-ns.val_set("users[].#", "Alice")  # append
-ns.val_set("users[].#", "Bob")  # append
-ns.val_set("users[].#", "Charlie")  # append
-print("users:", ns.val_get("users[].0"))  # Alice
-print("last:", ns.val_get("users[].#"))  # Charlie (# = last)
+ns._.val_set("users[].#", "Alice")  # append
+ns._.val_set("users[].#", "Bob")  # append
+ns._.val_set("users[].#", "Charlie")  # append
+print("users:", ns._.val_get("users[].0"))  # Alice
+print("last:", ns._.val_get("users[].#"))  # Charlie (# = last)
 
 # Set by index
-ns.val_set("users[].1", "Robert")
-print("updated:", ns.val_get("users[].1"))  # Robert
+ns._.val_set("users[].1", "Robert")
+print("updated:", ns._.val_get("users[].1"))  # Robert
 
 # Deep chain with arrays
-ns.val_set("teams[].#.name", "Backend")
-ns.val_set("teams[].#.name", "Frontend")
-print("team 0:", ns.val_get("teams[].0.name"))  # Backend
-print("team 1:", ns.val_get("teams[].1.name"))  # Frontend
+ns._.val_set("teams[].#.name", "Backend")
+ns._.val_set("teams[].#.name", "Frontend")
+print("team 0:", ns._.val_get("teams[].0.name"))  # Backend
+print("team 1:", ns._.val_get("teams[].1.name"))  # Frontend
 
 # Safe access with fallback
-print("missing:", ns.get_or_else("no.such.key", "N/A"))  # N/A
+print("missing:", ns._.get_or_else("no.such.key", "N/A"))  # N/A
 
 print("\nFinal structure:")
 print(ns)

--- a/examples/intermediate/07_config_management.py
+++ b/examples/intermediate/07_config_management.py
@@ -16,7 +16,7 @@ print("Production config:")
 print(f"  debug={config.debug}, db={config.database.host}")
 
 # Temporarily switch to development settings
-with config.overlay({"debug": True, "log_level": "DEBUG"}):
+with config._.overlay({"debug": True, "log_level": "DEBUG"}):
     print("\nDev overlay active:")
     print(f"  debug={config.debug}, log_level={config.log_level}")
     print(f"  db still={config.database.host}")  # unchanged
@@ -25,9 +25,9 @@ print("\nBack to production:")
 print(f"  debug={config.debug}, log_level={config.log_level}")
 
 # Nested overlays for testing
-with config.overlay({"cache_ttl": 0}):
+with config._.overlay({"cache_ttl": 0}):
     print(f"\nNo-cache overlay: ttl={config.cache_ttl}")
-    with config.overlay({"debug": True}):
+    with config._.overlay({"debug": True}):
         print(
             f"  + debug overlay: debug={config.debug}, ttl={config.cache_ttl}"
         )

--- a/examples/intermediate/08_copy_and_modify.py
+++ b/examples/intermediate/08_copy_and_modify.py
@@ -11,11 +11,11 @@ original = RNS(
 )
 
 # ── Shallow copy ────────────────────────────────────────────────
-shallow = original.copy()
+shallow = original._.copy()
 print("Shallow copy:", shallow.name)
 
 # ── Deep copy ───────────────────────────────────────────────────
-deep = original.deepcopy()
+deep = original._.deepcopy()
 deep.params.lr = 0.01
 deep.name = "experiment_2"
 print(f"Deep copy lr: {deep.params.lr}")  # 0.01
@@ -23,7 +23,7 @@ print(f"Original lr:  {original.params.lr}")  # 0.001
 
 # ── temporary() context manager ─────────────────────────────────
 print("\nUsing temporary():")
-with original.temporary() as tmp:
+with original._.temporary() as tmp:
     tmp.params.lr = 0.1
     tmp.params.epochs = 100
     tmp.results.accuracy = 0.99
@@ -33,8 +33,8 @@ print(f"  After:  lr={original.params.lr}, acc={original.results.accuracy}")
 
 # ── pop and delete ──────────────────────────────────────────────
 ns = RNS({"a": 1, "b": 2, "c": 3})
-val = ns.pop("b")
-print(f"\nPopped b={val}, remaining keys: {ns.keys()}")
+val = ns._.pop("b")
+print(f"\nPopped b={val}, remaining keys: {ns._.keys()}")
 
 del ns["c"]
-print(f"After del c: {ns.keys()}")
+print(f"After del c: {ns._.keys()}")

--- a/examples/real_world/14_api_responses.py
+++ b/examples/real_world/14_api_responses.py
@@ -35,9 +35,9 @@ print(f"Permissions: {resp.data.permissions}")
 print(f"Request ID: {resp.meta.request_id}")
 
 # Safe access for optional fields
-bio = resp.get_or_else("data.user.bio", "No bio set")
+bio = resp._.get_or_else("data.user.bio", "No bio set")
 print(f"Bio: {bio}")
 
 # Extract just what you need
-user_dict = resp.data.user.to_dict()
+user_dict = resp.data.user._.to_dict()
 print(f"\nUser dict keys: {list(user_dict.keys())}")

--- a/examples/real_world/15_ml_experiments.py
+++ b/examples/real_world/15_ml_experiments.py
@@ -27,7 +27,7 @@ experiment = RNS(
 )
 
 # Log parameters as flat dict (for MLflow, W&B, etc.)
-flat_params = experiment.to_dict(flatten_sep="/")
+flat_params = experiment._.to_dict(flatten_sep="/")
 print("Flat params for logger:")
 for k, v in flat_params.items():
     print(f"  {k}: {v}")
@@ -43,7 +43,7 @@ experiment["results"] = RNS(
 )
 
 # Save experiment as JSON
-experiment.save_json("/tmp/rns_experiment.json")
+experiment._.save_json("/tmp/rns_experiment.json")
 print(f"\nSaved experiment: {experiment.name}")
 
 # Load and compare later
@@ -55,5 +55,5 @@ print(f"  LR: {loaded.training.learning_rate}")
 # Quick hyperparameter sweep with overlay
 print("\nHyperparameter sweep:")
 for lr in [1e-5, 3e-5, 5e-5]:
-    with experiment.overlay({"training": RNS({"learning_rate": lr})}):
+    with experiment._.overlay({"training": RNS({"learning_rate": lr})}):
         print(f"  LR={experiment.training.learning_rate}")

--- a/src/recursivenamespace/main.py
+++ b/src/recursivenamespace/main.py
@@ -276,7 +276,11 @@ class recursivenamespace(SimpleNamespace):
             self._array_set_at_(target, key, int(head), rest, value)
 
     def _get_or_create_list_target_(self, key: str) -> List[Any]:
-        if not hasattr(self, key):
+        # Use ``key in self`` (which checks ``__dict__``) rather than
+        # ``hasattr`` — ``hasattr`` resolves class attributes too, so a
+        # deprecated method name like ``items`` would falsely look
+        # "present" and the bound method would be returned below.
+        if key not in self:
             self[key] = []
         target = self[key]
         if not isinstance(target, list):
@@ -317,7 +321,9 @@ class recursivenamespace(SimpleNamespace):
             raise SetChainKeyError(child, f"{key}[{index}]", sub_key)
 
     def _chain_set_value_(self, key: str, subs: List[str], value: Any) -> None:
-        if not hasattr(self, key):
+        # See note in ``_get_or_create_list_target_``: ``hasattr`` would
+        # find class-level deprecated method shims and skip auto-vivify.
+        if key not in self:
             self[key] = recursivenamespace(
                 None, self._supported__types_, self._use__raw_key_
             )
@@ -329,6 +335,12 @@ class recursivenamespace(SimpleNamespace):
             raise SetChainKeyError(target, key, sub_key)
 
     def _chain_get_array_(self, key: str, subs: List[str]) -> Any:
+        # Without this guard, a missing data field whose name matches a
+        # class method (e.g. ``items``) would resolve to a bound method
+        # via attribute lookup and hit the type-mismatch branch below
+        # with a confusing "method" type in the message.
+        if key not in self:
+            raise GetChainKeyError(None, key, utils.join_key(subs))
         target = self[key]
         subs_len = len(subs)
         if not isinstance(target, list):
@@ -356,8 +368,11 @@ class recursivenamespace(SimpleNamespace):
             raise GetChainKeyError(target, key, sub_key)
 
     def _chain_get_value_(self, key: str, subs: List[str]) -> Any:
-        target = self[key]
         sub_key = utils.join_key(subs)
+        # See ``_chain_get_array_``: guard against class-method shadow.
+        if key not in self:
+            raise GetChainKeyError(None, key, sub_key)
+        target = self[key]
         if isinstance(target, recursivenamespace):
             return _StaticImpl.val_get(target, sub_key)
         elif len(subs) == 1:

--- a/src/recursivenamespace/main.py
+++ b/src/recursivenamespace/main.py
@@ -199,9 +199,14 @@ class recursivenamespace(SimpleNamespace):
         if key in self._protected__keys_:
             raise KeyError(f"The key '{key}' is protected.")
         if key in _DEPRECATED_PUBLIC_METHODS:
+            # FutureWarning (not DeprecationWarning) so the signal is
+            # visible under Python's default filter. The shadow is an
+            # end-user-data event — the caller's data collides with a
+            # library method name — and they need to see it without
+            # opting in via -W default.
             warnings.warn(
                 _SHADOW_TEMPLATE.format(name=key),
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
         setattr(self, key, value)
@@ -926,8 +931,10 @@ setattr(recursivenamespace, "_", _Descriptor())
 # Two-tier protection. Hard-protected names load-bearing for internal
 # logic raise KeyError on data collision. Soft-protected public method
 # names (deprecated direct-call shims + classmethod factories) emit
-# DeprecationWarning and let the data win — callers can still reach the
-# methods via ``obj._.<name>(...)``.
+# FutureWarning and let the data win — callers can still reach the
+# methods via ``obj._.<name>(...)``. FutureWarning (vs DeprecationWarning
+# on the @_deprecated call shims) because shadow events are caused by
+# end-user data and must surface under Python's default warning filter.
 # All single-underscore class attrs — the ``_`` proxy plus every
 # private helper (_re_, _process_, _chain_*_, _iter_to_dict_, etc.)
 # and ``_logger_``. Excludes Python dunders.

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -151,26 +151,27 @@ class TestProtectedKeys:
     )
     def test_init_data_collides_with_method_warns_and_accepts(self, name):
         # Method names are soft-protected: data is accepted, a
-        # DeprecationWarning tells the caller to use obj._.<name>() for
-        # the method.
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        # FutureWarning tells the caller to use obj._.<name>() for
+        # the method. FutureWarning (not DeprecationWarning) so it's
+        # visible under Python's default warning filter.
+        with pytest.warns(FutureWarning, match="shadows"):
             ns = RNS({name: "x"})
         assert ns[name] == "x"
 
     def test_init_kwargs_collides_with_method_warns_and_accepts(self):
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             ns = RNS(items=[1, 2, 3])
         assert ns["items"] == [1, 2, 3]
 
     def test_setitem_method_name_warns_and_accepts(self):
         ns = RNS({"a": 1})
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             ns["to_dict"] = "shadowed"
         assert ns["to_dict"] == "shadowed"
 
     def test_val_set_method_name_warns_and_accepts(self):
         ns = RNS({"a": 1})
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             ns._.val_set("update", "shadowed")
         assert ns["update"] == "shadowed"
 
@@ -184,7 +185,7 @@ class TestProtectedKeys:
     def test_nested_dict_method_collision_also_warns(self):
         # Nested dicts are recursively wrapped, so the warning fires
         # for the inner shadowing too.
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             ns = RNS({"outer": {"to_dict": "x"}})
         assert ns.outer["to_dict"] == "x"
 
@@ -199,7 +200,7 @@ class TestProtectedKeys:
     def test_proxy_sees_shadowed_data_via_items(self):
         # After shadowing, obj._.items() should include the shadowing
         # entry alongside the rest of the data.
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             ns = RNS({"a": 1, "items": [1, 2, 3]})
         d = ns._.to_dict()
         assert d == {"a": 1, "items": [1, 2, 3]}
@@ -390,7 +391,7 @@ class TestRnsDecorator:
         def create():
             return {"to_dict": "x", "name": "foo"}
 
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             result = create()
         assert result["to_dict"] == "x"
         assert result.name == "foo"
@@ -400,7 +401,7 @@ class TestRnsDecorator:
         def create():
             return [1, 2, 3]
 
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             result = create()
         assert result["items"] == [1, 2, 3]
 
@@ -409,7 +410,7 @@ class TestRnsDecorator:
         def create():
             return {"to_dict": "x"}
 
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             result = create()
         assert result["to_dict"] == "x"
 
@@ -423,7 +424,7 @@ class TestRnsDecorator:
         def create():
             return Bad(items=[1, 2, 3], name="foo")
 
-        with pytest.warns(DeprecationWarning, match="shadows"):
+        with pytest.warns(FutureWarning, match="shadows"):
             result = create()
         assert result["items"] == [1, 2, 3]
 

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -314,6 +314,45 @@ class TestChainGetErrors:
             ns.val_get("a[].0.x.y")
 
 
+# ── Chain ops through deprecated method names ──────────────────
+
+
+class TestChainThroughDeprecatedNames:
+    """Regression: chain helpers used ``hasattr`` to test for an
+    existing key, which falsely matched class-level deprecated method
+    shims (``update``, ``items``, ``to_dict``, ...). Chain set/get
+    through such a name resolved to the bound method instead of the
+    user's data and raised SetChainKeyError / returned a method.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        ["update", "items", "keys", "values", "to_dict", "pop", "copy"],
+    )
+    def test_set_chain_through_shadow_name(self, name):
+        ns = RNS({})
+        ns._.val_set(f"{name}.inner", 42)
+        assert ns._.val_get(f"{name}.inner") == 42
+
+    @pytest.mark.parametrize("name", ["items", "values", "keys"])
+    def test_set_array_under_shadow_name(self, name):
+        ns = RNS({})
+        ns._.val_set(f"{name}[].#", "a")
+        ns._.val_set(f"{name}[].#", "b")
+        assert ns._.val_get(f"{name}[].0") == "a"
+        assert ns._.val_get(f"{name}[].1") == "b"
+
+    def test_get_missing_shadow_name_raises_chain_error(self):
+        ns = RNS({})
+        with pytest.raises(GetChainKeyError):
+            ns._.val_get("update.inner")
+
+    def test_get_array_missing_shadow_name_raises_chain_error(self):
+        ns = RNS({})
+        with pytest.raises(GetChainKeyError):
+            ns._.val_get("items[].0")
+
+
 # ── get_or_else ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **Fix** ([d627072](../../commit/d627072)): chain-key ops (`val_set`/`val_get` and array `[]` forms) used `hasattr` / attribute fallback to test for existing data, which falsely matched class-level deprecated method shims (`update`, `items`, `to_dict`, …). Chain ops through any such name on a fresh `RNS({})` raised `SetChainKeyError` or returned a bound method. Now gated on `__dict__` membership; added parametrized regression tests across all shadowed names (157 → 169 tests).
- **Docs/examples** ([5422bee](../../commit/5422bee)): migrated 47 direct-call sites across 12 examples, 1 benchmark, and the README feature bullet to the `obj._.method(...)` proxy form so runnable docs no longer emit `DeprecationWarning`.
- **Warning escalation** ([cc85075](../../commit/cc85075)): method-shadow signal upgraded from `DeprecationWarning` to `FutureWarning` so end users see it under Python's default filter.

## Test plan

- [x] `pytest -q` — 169 passed (12 new regression tests for chain ops through deprecated names)
- [x] All 12 example scripts run cleanly under `python -W error::DeprecationWarning`
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, codespell)
- [ ] Reviewer to confirm release workflow tags `v0.0.5` and regenerates CHANGELOG section on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)